### PR TITLE
Fix NSTimeInterval abs function warning (for compiler warnings from Xcode 6.3)

### DIFF
--- a/source/Helper/PTDBeanRemoteFirmwareVersionManager.m
+++ b/source/Helper/PTDBeanRemoteFirmwareVersionManager.m
@@ -144,7 +144,7 @@ static PTDBeanRemoteFirmwareVersionManager *_instance = nil;
 {
     NSURLRequest *firmwareVersionRequest;
     
-    if ( ![self firmwareCheckDate] || abs([[self firmwareCheckDate] timeIntervalSinceNow]) > 3600 ) {
+    if ( ![self firmwareCheckDate] || fabs([[self firmwareCheckDate] timeIntervalSinceNow]) > 3600. ) {
         firmwareVersionRequest = [NSURLRequest requestWithURL:[NSURL URLWithString:PTDFirmwareVersionUrlString] cachePolicy:NSURLRequestReloadIgnoringLocalCacheData timeoutInterval:10];
         [NSURLConnection sendAsynchronousRequest:firmwareVersionRequest queue:self.operationQueue completionHandler:^(NSURLResponse *response, NSData *data, NSError *connectionError) {
             NSError *jsonError;


### PR DESCRIPTION
`-[NSTimeInterval timeIntervalSinceNow]` returns `NSTimeInterval` which is a alias of `double`, so we should use `fabs` instead of `abs`