### PR TITLE
Refine equality and hash method of PTDBean

### DIFF
--- a/source/PTDBean.m
+++ b/source/PTDBean.m
@@ -62,6 +62,15 @@ typedef enum { //These occur in sequence
 }
 
 #pragma mark - Public Methods
+
+- (BOOL)isEqual:(id)object {
+    return [object isKindOfClass:[self class]] ? [self isEqualToBean:object] : NO;
+}
+
+- (NSUInteger)hash {
+    return self.identifier.hash;
+}
+
 - (BOOL)isEqualToBean:(PTDBean *)bean {
     if([self.identifier isEqual:bean.identifier]){
         return YES;


### PR DESCRIPTION
Override `isEqual:` and `hash` by `isEqualToBean:`