### PR TITLE
Fix memory leak in `UUIDToString` method

### DIFF
--- a/source/Helper/BEAN_Helper.m
+++ b/source/Helper/BEAN_Helper.m
@@ -68,7 +68,9 @@
 {
     if (!UUID) return "NULL";
     CFStringRef s = CFUUIDCreateString(NULL, UUID);
-    return CFStringGetCStringPtr(s, 0);
+    const char *r = CFStringGetCStringPtr(s, 0);
+    CFRelease(s);
+    return r;
 }
     
 +(NSString *) UUIDToNSString:(CFUUIDRef) UUID

--- a/source/Helper/PTDBEAN_Helper.m
+++ b/source/Helper/PTDBEAN_Helper.m
@@ -68,7 +68,9 @@
 {
     if (!UUID) return "NULL";
     CFStringRef s = CFUUIDCreateString(NULL, UUID);
-    return CFStringGetCStringPtr(s, 0);
+    const char *r = CFStringGetCStringPtr(s, 0);
+    CFRelease(s);
+    return r;
 }
     
 +(NSString *) UUIDToNSString:(CFUUIDRef) UUID


### PR DESCRIPTION
CoreFoundation follows `create rule` which means when you used a function named with **Create**, you must release the returned object after using it.