### PR TITLE
spec: bump version to 0.10.0

### DIFF
--- a/Bean-iOS-OSX-SDK.podspec
+++ b/Bean-iOS-OSX-SDK.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.author             = { "Punch Through Design" => "info@punchthrough.com" }
   s.documentation_url = 'http://punchthrough.com/files/bean/sdk-docs/index.html'
 
-  s.ios.deployment_target = "9.0"
+  s.ios.deployment_target = "7.0"
   s.osx.deployment_target = "10.9"
 
   s.source       = { :git => "https://github.com/PunchThrough/Bean-iOS-OSX-SDK.git", :tag => s.version.to_s, :submodules => true }

--- a/Bean-iOS-OSX-SDK.podspec
+++ b/Bean-iOS-OSX-SDK.podspec
@@ -2,7 +2,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "Bean-iOS-OSX-SDK"
-  s.version      = "0.9.0"
+  s.version      = "0.10.0"
   s.summary      = "Punch Through Design's SDK for speeding up development with the LightBlue Bean development platform"
   s.homepage     = "https://github.com/PunchThrough/Bean-iOS-OSX-SDK"
   s.license      = { :type => "MIT", :file => "LICENSE.txt" }
@@ -10,10 +10,10 @@ Pod::Spec.new do |s|
   s.author             = { "Punch Through Design" => "info@punchthrough.com" }
   s.documentation_url = 'http://punchthrough.com/files/bean/sdk-docs/index.html'
 
-  s.ios.deployment_target = "7.0"
+  s.ios.deployment_target = "9.0"
   s.osx.deployment_target = "10.9"
 
-  s.source       = { :git => "https://github.com/PunchThrough/Bean-iOS-OSX-SDK.git", :tag => "0.9.0", :submodules => true }
+  s.source       = { :git => "https://github.com/PunchThrough/Bean-iOS-OSX-SDK.git", :tag => s.version.to_s, :submodules => true }
 
   s.source_files  = "App Message Definitions/*.{h,m}","Bean OSX Static Library/**/*.{h,m}","source","source/**/*.{h,m}"
   s.exclude_files = "Bean OSX Static Library/Bean OSX LibraryTests/**/*.{h,m}"
@@ -28,4 +28,3 @@ Pod::Spec.new do |s|
   s.xcconfig = { "HEADER_SEARCH_PATHS" => "$(SRCROOT)/../bean-apple-sdk/source/Public" }
 
 end
-


### PR DESCRIPTION
Ready for review.

Bumps iOS deployment target to 9.0, since some changes were made for iOS 9.0 in #14 (now merged).

Don't forget to tag the merge commit on master with `0.10.0` after merging.