### PR TITLE
Use https in latest firmware url

### DIFF
--- a/Bean-iOS-OSX-SDK.podspec
+++ b/Bean-iOS-OSX-SDK.podspec
@@ -2,7 +2,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "Bean-iOS-OSX-SDK"
-  s.version      = "0.10.0"
+  s.version      = "0.10.1"
   s.summary      = "Punch Through Design's SDK for speeding up development with the LightBlue Bean development platform"
   s.homepage     = "https://github.com/PunchThrough/Bean-iOS-OSX-SDK"
   s.license      = { :type => "MIT", :file => "LICENSE.txt" }

--- a/source/Helper/PTDBeanRemoteFirmwareVersionManager.m
+++ b/source/Helper/PTDBeanRemoteFirmwareVersionManager.m
@@ -12,7 +12,7 @@ static NSString *PTDFirmwareCheckDateKey = @"PTDFirmwareCheckDateKey";
 static NSString *PTDNewestFirmwareVersionKey = @"PTDNewestFirmwareVersionKey";
 static NSString *PTDFirmwareUrlStringAKey = @"PTDFirmwareUrlStringAKey";
 static NSString *PTDFirmwareUrlStringBKey = @"PTDFirmwareUrlStringBKey";
-static NSString *PTDFirmwareVersionUrlString = @"http://punchthrough.com/files/bean/oad-images/latest.php";
+static NSString *PTDFirmwareVersionUrlString = @"https://punchthrough.com/files/bean/oad-images/latest.php";
 
 static NSString *PTDFirmwareVersionJSONKey = @"version";
 static NSString *PTDFirmwareUrlBaseKey = @"url";


### PR DESCRIPTION
Use https instead of http when grabbing latest firmware version (required for iOS 9)