### PR TITLE
Fix #31 Allow rediscovering bean by peripheral identifier

### DIFF
--- a/source/PTDBeanManager.m
+++ b/source/PTDBeanManager.m
@@ -59,6 +59,25 @@ NSString * const PTDBeanManagerConnectionOptionProfilesRequiredToConnect    = @"
     return cbcentralmanager?(BeanManagerState)cbcentralmanager.state:0;
 }
 
+-(void)restoreBeans:(NSArray<NSUUID*>*)identifiers{
+    NSArray* peripherals = [cbcentralmanager retrievePeripheralsWithIdentifiers:identifiers];
+    for(CBPeripheral* beanPeripheral in peripherals){
+        PTDBean* bean;
+        //If this bean is already in out records, pass it back to the delegate as having been discovered!
+        if((bean = [beanRecords objectForKey:beanPeripheral.identifier])){
+            [self __notifyDelegateOfDiscoveredBean:bean error:nil];
+        }else{
+            if((bean = [[PTDBean alloc] initWithPeripheral:beanPeripheral beanManager:self])){
+                [beanRecords setObject:bean forKey:bean.identifier];
+                bean.RSSI = [beanPeripheral RSSI_Universal];
+                bean.lastDiscovered = [NSDate date];
+                bean.state = BeanState_Discovered;
+                [self __notifyDelegateOfDiscoveredBean:bean error:nil];
+            }
+        }
+    }
+}
+
 -(void)startScanningForBeans_error:(NSError**)error{
     //Stop any previous scan
     [self stopScanningForBeans_error:nil];

--- a/source/Public/PTDBeanManager.h
+++ b/source/Public/PTDBeanManager.h
@@ -137,6 +137,13 @@ extern NSString * const PTDBeanManagerConnectionOptionProfilesRequiredToConnect;
 - (instancetype)initWithDelegate:(id<PTDBeanManagerDelegate>)delegate stateRestorationIdentifier:(NSString *)stateRestorationIdentifier;
 #endif
 
+/**
+ *  Restore Beans
+ *
+ *  @param identifiers UUID identifiers of Beans to instantiate without re-scanning.
+ */
+-(void)restoreBeans:(NSArray<NSUUID*>*)identifiers;
+
 /// @name Scanning or Stopping Scans for Beans
 /**
  *  Begins scanning for Beans


### PR DESCRIPTION
This feels hacky, but it serves my needs.