### PR TITLE
Fixed crash when trying to use bean just after reconnect

### DIFF
--- a/source/PTDBean.m
+++ b/source/PTDBean.m
@@ -382,6 +382,8 @@ typedef enum { //These occur in sequence
 
 -(void)discoverServices{
     
+    profilesValidated = [[NSMutableSet alloc] init];
+    
     oad_profile = nil;
     deviceInfo_profile = nil;
     gatt_serial_profile = nil;


### PR DESCRIPTION
Keep intermediate state while rediscovering services.

Otherwise bean goes to connected-and-validated state too early – while the services are still `nil`. At this time, calling any operation that rely on any of these services will crash the app.