### PR TITLE
refer to submodules over https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "App Message Definitions"]
 	path = App Message Definitions
-	url = git@github.com:PunchThrough/bean-serial-protocol.git
+	url = https://github.com/PunchThrough/bean-serial-protocol.git


### PR DESCRIPTION
Installing pod should not require ssh keys on github.